### PR TITLE
Add scheduled command to persist DolarAPI VES rates

### DIFF
--- a/app/Console/Commands/StoreDolarRates.php
+++ b/app/Console/Commands/StoreDolarRates.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Rate;
+use App\Services\DolarRateService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Throwable;
+
+class StoreDolarRates extends Command
+{
+    protected $signature = 'rates:store-dolar';
+
+    protected $description = 'Fetch and store VES to USD prices from DolarAPI.';
+
+    public function __construct(private readonly DolarRateService $service)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $this->info('Fetching VES to USD prices from DolarAPI...');
+
+        try {
+            $rates = $this->service->fetchRates();
+        } catch (Throwable $exception) {
+            $this->error('Failed to fetch rates: '.$exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($rates->isEmpty()) {
+            $this->warn('DolarAPI returned no rates.');
+
+            return self::FAILURE;
+        }
+
+        $stored = $this->storeRates($rates);
+
+        $this->info("Stored {$stored} rate records.");
+
+        return self::SUCCESS;
+    }
+
+    private function storeRates(Collection $rates): int
+    {
+        return $rates->reduce(function (int $count, array $rate): int {
+            Rate::create([
+                'source' => $rate['source'],
+                'value' => number_format($rate['value'], 4, '.', ''),
+                'currency' => $rate['currency'],
+                'effective_at' => $rate['effective_at'],
+            ]);
+
+            return $count + 1;
+        }, 0);
+    }
+}

--- a/app/Services/DolarRateService.php
+++ b/app/Services/DolarRateService.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\CarbonInterface;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+class DolarRateService
+{
+    private const SOURCE_MAP = [
+        'oficial' => 'BCV',
+        'paralelo' => 'Paralelo',
+    ];
+
+    public function fetchRates(): Collection
+    {
+        $baseUrl = rtrim(config('services.dolar_api.base_url', 'https://ve.dolarapi.com'), '/');
+
+        $response = Http::baseUrl($baseUrl)
+            ->timeout(config('services.dolar_api.timeout', 10))
+            ->acceptJson()
+            ->get('/v1/dolares')
+            ->throw();
+
+        $data = $response->json();
+
+        return collect(is_array($data) ? $data : [])
+            ->map(function ($rate) {
+                if (! is_array($rate)) {
+                    return null;
+                }
+
+                return $this->transformRate($rate);
+            })
+            ->filter()
+            ->values();
+    }
+
+    private function transformRate(array $rate): ?array
+    {
+        $sourceKey = Str::of($rate['fuente'] ?? '')->lower()->value();
+        $source = self::SOURCE_MAP[$sourceKey] ?? null;
+
+        if ($source === null) {
+            return null;
+        }
+
+        $value = $rate['promedio'] ?? null;
+
+        if ($value === null) {
+            return null;
+        }
+
+        $effectiveAt = $this->resolveEffectiveAt($rate['fechaActualizacion'] ?? null);
+
+        return [
+            'source' => $source,
+            'value' => (float) $value,
+            'currency' => 'VES',
+            'effective_at' => $effectiveAt,
+        ];
+    }
+
+    private function resolveEffectiveAt(?string $timestamp): CarbonInterface
+    {
+        if ($timestamp === null) {
+            return now()->utc();
+        }
+
+        return Carbon::parse($timestamp)->utc();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\StoreDolarRates;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Foundation\Application;
@@ -14,6 +15,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withCommands([
+        StoreDolarRates::class,
+    ])
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
 

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,9 @@ return [
         ],
     ],
 
+    'dolar_api' => [
+        'base_url' => env('DOLAR_API_BASE_URL', 'https://ve.dolarapi.com'),
+        'timeout' => env('DOLAR_API_TIMEOUT', 10),
+    ],
+
 ];

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,17 @@
 <?php
 
+use App\Console\Commands\StoreDolarRates;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+foreach (['12:00', '13:30', '16:00', '21:00'] as $time) {
+    Schedule::command(StoreDolarRates::class)
+        ->timezone('America/Caracas')
+        ->dailyAt($time)
+        ->description('Fetch and store VES to USD prices from DolarAPI.');
+}


### PR DESCRIPTION
## Summary
- add a dedicated service to fetch and normalize VES to USD prices from DolarAPI
- introduce an artisan command that stores the fetched rates and register it with the application bootstrap
- schedule the command to run at 12:00, 13:30, 16:00, and 21:00 America/Caracas time and expose API configuration options