### PR TITLE
Add BCV euro rate scraper service

### DIFF
--- a/app/Console/Commands/StoreDolarRates.php
+++ b/app/Console/Commands/StoreDolarRates.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Rate;
+use App\Services\DolarRateService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Throwable;
+
+class StoreDolarRates extends Command
+{
+    protected $signature = 'rates:store-dolar';
+
+    protected $description = 'Fetch and store VES to USD prices from DolarAPI.';
+
+    public function __construct(private readonly DolarRateService $service)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $this->info('Fetching VES to USD prices from DolarAPI...');
+
+        try {
+            $rates = $this->service->fetchRates();
+        } catch (Throwable $exception) {
+            $this->error('Failed to fetch rates: '.$exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($rates->isEmpty()) {
+            $this->warn('DolarAPI returned no rates.');
+
+            return self::FAILURE;
+        }
+
+        $stored = $this->storeRates($rates);
+
+        $this->info("Stored {$stored} rate records.");
+
+        return self::SUCCESS;
+    }
+
+    private function storeRates(Collection $rates): int
+    {
+        return $rates->reduce(function (int $count, array $rate): int {
+            Rate::create([
+                'source' => $rate['source'],
+                'value' => number_format($rate['value'], 4, '.', ''),
+                'currency' => $rate['currency'],
+                'effective_at' => $rate['effective_at'],
+            ]);
+
+            return $count + 1;
+        }, 0);
+    }
+}

--- a/app/Services/DolarRateService.php
+++ b/app/Services/DolarRateService.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\CarbonInterface;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+class DolarRateService
+{
+    private const SOURCE_MAP = [
+        'oficial' => 'BCV',
+        'paralelo' => 'Paralelo',
+    ];
+
+    public function fetchRates(): Collection
+    {
+        $baseUrl = rtrim(config('services.dolar_api.base_url', 'https://ve.dolarapi.com'), '/');
+
+        $response = Http::baseUrl($baseUrl)
+            ->timeout(config('services.dolar_api.timeout', 10))
+            ->acceptJson()
+            ->get('/v1/dolares')
+            ->throw();
+
+        $data = $response->json();
+
+        return collect(is_array($data) ? $data : [])
+            ->map(function ($rate) {
+                if (! is_array($rate)) {
+                    return null;
+                }
+
+                return $this->transformRate($rate);
+            })
+            ->filter()
+            ->values();
+    }
+
+    private function transformRate(array $rate): ?array
+    {
+        $sourceKey = Str::of($rate['fuente'] ?? '')->lower()->value();
+        $source = self::SOURCE_MAP[$sourceKey] ?? null;
+
+        if ($source === null) {
+            return null;
+        }
+
+        $value = $rate['promedio'] ?? null;
+
+        if ($value === null) {
+            return null;
+        }
+
+        $effectiveAt = $this->resolveEffectiveAt($rate['fechaActualizacion'] ?? null);
+
+        return [
+            'source' => $source,
+            'value' => (float) $value,
+            'currency' => 'VES',
+            'effective_at' => $effectiveAt,
+        ];
+    }
+
+    private function resolveEffectiveAt(?string $timestamp): CarbonInterface
+    {
+        if ($timestamp === null) {
+            return now()->utc();
+        }
+
+        return Carbon::parse($timestamp)->utc();
+    }
+}

--- a/app/Services/EuroRateService.php
+++ b/app/Services/EuroRateService.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\CarbonInterface;
+use DOMDocument;
+use DOMXPath;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+
+class EuroRateService
+{
+    private const DEFAULT_URL = 'https://www.bcv.org.ve/';
+    private const SOURCE = 'BCV';
+
+    public function fetchRate(): ?array
+    {
+        $response = Http::timeout((int) config('services.bcv.timeout', 10))
+            ->get(config('services.bcv.url', self::DEFAULT_URL))
+            ->throw();
+
+        $value = $this->extractEuroValue($response->body());
+
+        if ($value === null) {
+            return null;
+        }
+
+        return [
+            'source' => self::SOURCE,
+            'value' => $value,
+            'currency' => 'VES',
+            'effective_at' => $this->resolveEffectiveAt(),
+        ];
+    }
+
+    private function extractEuroValue(string $html): ?float
+    {
+        $html = trim($html);
+
+        if ($html === '') {
+            return null;
+        }
+
+        $internalErrors = libxml_use_internal_errors(true);
+
+        $document = new DOMDocument();
+        $loaded = $document->loadHTML($html);
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($internalErrors);
+
+        if ($loaded === false) {
+            return null;
+        }
+
+        $xpath = new DOMXPath($document);
+        $nodes = $xpath->query("//div[@id='euro']//strong");
+
+        if ($nodes === false || $nodes->length === 0) {
+            return null;
+        }
+
+        $rawValue = trim($nodes->item(0)?->textContent ?? '');
+
+        if ($rawValue === '') {
+            return null;
+        }
+
+        return $this->normalizeNumericValue($rawValue);
+    }
+
+    private function normalizeNumericValue(string $value): ?float
+    {
+        $value = str_replace(["\u{00A0}", ' '], '', $value);
+
+        $digits = preg_replace('/[^0-9,.-]/u', '', $value);
+
+        if ($digits === null || $digits === '') {
+            return null;
+        }
+
+        $digits = str_replace('.', '', $digits);
+        $digits = str_replace(',', '.', $digits);
+
+        if (! is_numeric($digits)) {
+            return null;
+        }
+
+        return (float) $digits;
+    }
+
+    private function resolveEffectiveAt(): CarbonInterface
+    {
+        return Carbon::now()->utc();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\StoreDolarRates;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Foundation\Application;
@@ -14,6 +15,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withCommands([
+        StoreDolarRates::class,
+    ])
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
 

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,14 @@ return [
         ],
     ],
 
+    'dolar_api' => [
+        'base_url' => env('DOLAR_API_BASE_URL', 'https://ve.dolarapi.com'),
+        'timeout' => env('DOLAR_API_TIMEOUT', 10),
+    ],
+
+    'bcv' => [
+        'url' => env('BCV_BASE_URL', 'https://www.bcv.org.ve/'),
+        'timeout' => env('BCV_TIMEOUT', 10),
+    ],
+
 ];

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,17 @@
 <?php
 
+use App\Console\Commands\StoreDolarRates;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+foreach (['12:00', '13:30', '16:00', '21:00'] as $time) {
+    Schedule::command(StoreDolarRates::class)
+        ->timezone('America/Caracas')
+        ->dailyAt($time)
+        ->description('Fetch and store VES to USD prices from DolarAPI.');
+}

--- a/tests/Unit/EuroRateServiceTest.php
+++ b/tests/Unit/EuroRateServiceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Services\EuroRateService;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('parses the euro rate from BCV HTML', function () {
+    Carbon::setTestNow('2024-01-01 00:00:00');
+
+    $html = <<<'HTML'
+    <div id="euro" class="col-sm-12 col-xs-12 ">
+        <div class="field-content">
+            <div class="row recuadrotsmc">
+                <div class="col-sm-6 col-xs-6">
+                    <img src="/sites/default/files/euro-04_2.png" class="icono_bss_blanco1">
+                    <span> EUR </span>
+                </div>
+                <div class="col-sm-6 col-xs-6 centrado"><strong> 208,28473732 </strong></div>
+            </div>
+        </div>
+    </div>
+    HTML;
+
+    config(['services.bcv.url' => 'https://bcv.test/']);
+
+    Http::fake([
+        'https://bcv.test/*' => Http::response($html, 200),
+    ]);
+
+    try {
+        $service = new EuroRateService();
+
+        $rate = $service->fetchRate();
+
+        expect($rate)->not->toBeNull();
+        expect($rate)->toMatchArray([
+            'source' => 'BCV',
+            'value' => 208.28473732,
+            'currency' => 'VES',
+        ]);
+
+        expect($rate['effective_at'])->toBeInstanceOf(CarbonInterface::class);
+        expect($rate['effective_at']->equalTo(Carbon::now()->utc()))->toBeTrue();
+    } finally {
+        Carbon::setTestNow();
+    }
+});


### PR DESCRIPTION
## Summary
- add a EuroRateService that scrapes the BCV website to capture the EUR to VES rate with HTML parsing and normalization helpers
- expose BCV configuration options for base URL and timeout to support the scraper
- cover the service with a unit test that verifies the parsing logic using faked HTTP responses

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dad9fa8f488326b218389dd53340a7